### PR TITLE
Fix UUID validation to accept uppercase

### DIFF
--- a/repeatwise-server/src/main/java/com/repeatwise/util/ValidationUtils.java
+++ b/repeatwise-server/src/main/java/com/repeatwise/util/ValidationUtils.java
@@ -47,8 +47,8 @@ public final class ValidationUtils {
      * Validates if the given string is a valid UUID
      */
     public static boolean isValidUuid(String uuid) {
-        return StringUtils.isNotBlank(uuid) && 
-               uuid.matches("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
+        return StringUtils.isNotBlank(uuid) &&
+               uuid.matches("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
     }
     
     /**

--- a/repeatwise-server/src/test/java/com/repeatwise/util/ValidationUtilsTest.java
+++ b/repeatwise-server/src/test/java/com/repeatwise/util/ValidationUtilsTest.java
@@ -1,0 +1,20 @@
+package com.repeatwise.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidationUtilsTest {
+
+    @Test
+    void isValidUuid_ShouldAcceptUppercaseLetters() {
+        String uppercaseUuid = "A0EEBBAD-5D1A-11D1-9A0C-0000F8752B83";
+        assertTrue(ValidationUtils.isValidUuid(uppercaseUuid));
+    }
+
+    @Test
+    void isValidUuid_ShouldRejectInvalidFormat() {
+        String invalidUuid = "invalid-uuid";
+        assertFalse(ValidationUtils.isValidUuid(invalidUuid));
+    }
+}


### PR DESCRIPTION
## Summary
- allow ValidationUtils.isValidUuid to accept uppercase hexadecimal letters
- add ValidationUtils tests for UUID validation

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894ad98c23c8331bf8d554510388910