### PR TITLE
fix duplicated context path causing auth 403

### DIFF
--- a/repeatwise-server/src/main/resources/application.properties
+++ b/repeatwise-server/src/main/resources/application.properties
@@ -3,7 +3,6 @@
 # ==============================================
 spring.application.name=repeatwise-server
 server.port=8080
-server.servlet.context-path=/api/v1
 
 # ==============================================
 # DATABASE CONFIGURATION


### PR DESCRIPTION
## Summary
- remove server.servlet.context-path configuration to avoid double `/api/v1` prefix

## Testing
- `mvn -q -pl repeatwise-server test` *(fails: Non-resolvable import POM... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894b53fd22c8331b5b86e5fd89549e0