### PR TITLE
feat(review-history): add clean architecture module

### DIFF
--- a/spaced_learning_app/lib/core/converters/datetime_utc_converter.dart
+++ b/spaced_learning_app/lib/core/converters/datetime_utc_converter.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+
+/// Converter for ISO-8601 UTC strings to [DateTime] and back.
+class DateTimeUtcConverter implements JsonConverter<DateTime, String> {
+  const DateTimeUtcConverter();
+
+  @override
+  DateTime fromJson(String json) {
+    if (json.isEmpty) {
+      throw const FormatException('Empty DateTime string');
+    }
+    final date = DateTime.tryParse(json);
+    if (date == null) {
+      throw FormatException('Invalid DateTime format: $json');
+    }
+    return date.toUtc();
+  }
+
+  @override
+  String toJson(DateTime object) {
+    return object.toUtc().toIso8601String();
+  }
+}

--- a/spaced_learning_app/lib/core/exceptions/parse_exception.dart
+++ b/spaced_learning_app/lib/core/exceptions/parse_exception.dart
@@ -1,0 +1,8 @@
+/// Thrown when JSON parsing fails.
+class ParseException implements Exception {
+  final String message;
+  const ParseException(this.message);
+
+  @override
+  String toString() => 'ParseException: $message';
+}

--- a/spaced_learning_app/lib/core/pagination/page.dart
+++ b/spaced_learning_app/lib/core/pagination/page.dart
@@ -1,0 +1,16 @@
+/// Generic page result for paginated endpoints.
+class Page<T> {
+  final List<T> content;
+  final int page;
+  final int size;
+  final int totalElements;
+  final int totalPages;
+
+  const Page({
+    required this.content,
+    required this.page,
+    required this.size,
+    required this.totalElements,
+    required this.totalPages,
+  });
+}

--- a/spaced_learning_app/lib/core/pagination/page_dto.dart
+++ b/spaced_learning_app/lib/core/pagination/page_dto.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'page_dto.freezed.dart';
+part 'page_dto.g.dart';
+
+@Freezed(genericArgumentFactories: true)
+class PageDto<T> with _$PageDto<T> {
+  const factory PageDto({
+    required List<T> content,
+    required int page,
+    required int size,
+    required int totalElements,
+    required int totalPages,
+  }) = _PageDto<T>;
+
+  factory PageDto.fromJson(
+    Map<String, dynamic> json,
+    T Function(Object?) fromJsonT,
+  ) => _$PageDtoFromJson(json, fromJsonT);
+}

--- a/spaced_learning_app/lib/features/review_history/data/datasources/review_history_remote_data_source.dart
+++ b/spaced_learning_app/lib/features/review_history/data/datasources/review_history_remote_data_source.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+import 'package:spaced_learning_app/core/pagination/page_dto.dart';
+import 'package:spaced_learning_app/features/review_history/data/models/review_history_create_request_dto.dart';
+import 'package:spaced_learning_app/features/review_history/data/models/review_history_dto.dart';
+import 'package:spaced_learning_app/features/review_history/data/models/review_history_update_request_dto.dart';
+
+part 'review_history_remote_data_source.g.dart';
+
+@RestApi()
+abstract class ReviewHistoryRemoteDataSource {
+  factory ReviewHistoryRemoteDataSource(Dio dio, {String baseUrl}) =
+      _ReviewHistoryRemoteDataSource;
+
+  @POST('/reviews')
+  Future<ReviewHistoryDto> create(
+    @Body() ReviewHistoryCreateRequestDto body,
+  );
+
+  @GET('/reviews/{id}')
+  Future<ReviewHistoryDto> getById(@Path('id') String id);
+
+  @PUT('/reviews/{id}')
+  Future<ReviewHistoryDto> update(
+    @Path('id') String id,
+    @Body() ReviewHistoryUpdateRequestDto body,
+  );
+
+  @GET('/reviews/set/{setId}')
+  Future<PageDto<ReviewHistoryDto>> getBySet(
+    @Path('setId') String setId,
+    @Query('page') int page,
+    @Query('size') int size,
+  );
+}

--- a/spaced_learning_app/lib/features/review_history/data/mappers/review_history_mapper.dart
+++ b/spaced_learning_app/lib/features/review_history/data/mappers/review_history_mapper.dart
@@ -1,0 +1,64 @@
+import 'package:spaced_learning_app/core/exceptions/parse_exception.dart';
+import 'package:spaced_learning_app/core/pagination/page.dart';
+import 'package:spaced_learning_app/core/pagination/page_dto.dart';
+import 'package:spaced_learning_app/features/review_history/domain/entities/review_history.dart';
+import 'package:spaced_learning_app/features/review_history/domain/entities/review_history_create.dart';
+import 'package:spaced_learning_app/features/review_history/domain/entities/review_history_update.dart';
+import 'package:spaced_learning_app/features/review_history/data/models/review_history_create_request_dto.dart';
+import 'package:spaced_learning_app/features/review_history/data/models/review_history_dto.dart';
+import 'package:spaced_learning_app/features/review_history/data/models/review_history_update_request_dto.dart';
+
+class ReviewHistoryMapper {
+  ReviewHistoryMapper._();
+
+  static ReviewHistory fromDto(ReviewHistoryDto dto) {
+    if (dto.id.isEmpty) {
+      throw const ParseException('id is empty');
+    }
+    if (dto.setId.isEmpty) {
+      throw const ParseException('setId is empty');
+    }
+    return ReviewHistory(
+      id: dto.id,
+      setId: dto.setId,
+      setName: dto.setName,
+      cycleNo: dto.cycleNo,
+      reviewNo: dto.reviewNo,
+      score: dto.score,
+      status: dto.status,
+      note: dto.note,
+      createdAt: dto.createdAt,
+      updatedAt: dto.updatedAt,
+    );
+  }
+
+  static ReviewHistoryCreateRequestDto toCreateDto(ReviewHistoryCreate entity) {
+    return ReviewHistoryCreateRequestDto(
+      setId: entity.setId,
+      cycleNo: entity.cycleNo,
+      reviewNo: entity.reviewNo,
+      score: entity.score,
+      status: entity.status,
+      note: entity.note,
+    );
+  }
+
+  static ReviewHistoryUpdateRequestDto toUpdateDto(ReviewHistoryUpdate entity) {
+    return ReviewHistoryUpdateRequestDto(
+      score: entity.score,
+      status: entity.status,
+      note: entity.note,
+    );
+  }
+
+  static Page<ReviewHistory> mapPage(PageDto<ReviewHistoryDto> dto) {
+    final items = dto.content.map(fromDto).toList();
+    return Page(
+      content: items,
+      page: dto.page,
+      size: dto.size,
+      totalElements: dto.totalElements,
+      totalPages: dto.totalPages,
+    );
+  }
+}

--- a/spaced_learning_app/lib/features/review_history/data/models/review_history_create_request_dto.dart
+++ b/spaced_learning_app/lib/features/review_history/data/models/review_history_create_request_dto.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:spaced_learning_app/features/review_history/domain/entities/review_status.dart';
+
+part 'review_history_create_request_dto.freezed.dart';
+part 'review_history_create_request_dto.g.dart';
+
+@freezed
+class ReviewHistoryCreateRequestDto with _$ReviewHistoryCreateRequestDto {
+  const factory ReviewHistoryCreateRequestDto({
+    required String setId,
+    required int cycleNo,
+    required int reviewNo,
+    int? score,
+    required ReviewStatus status,
+    String? note,
+  }) = _ReviewHistoryCreateRequestDto;
+
+  factory ReviewHistoryCreateRequestDto.fromJson(Map<String, dynamic> json) =>
+      _$ReviewHistoryCreateRequestDtoFromJson(json);
+}

--- a/spaced_learning_app/lib/features/review_history/data/models/review_history_dto.dart
+++ b/spaced_learning_app/lib/features/review_history/data/models/review_history_dto.dart
@@ -1,0 +1,25 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:spaced_learning_app/core/converters/datetime_utc_converter.dart';
+import 'package:spaced_learning_app/features/review_history/domain/entities/review_status.dart';
+
+part 'review_history_dto.freezed.dart';
+part 'review_history_dto.g.dart';
+
+@freezed
+class ReviewHistoryDto with _$ReviewHistoryDto {
+  const factory ReviewHistoryDto({
+    required String id,
+    required String setId,
+    required String setName,
+    required int cycleNo,
+    required int reviewNo,
+    int? score,
+    required ReviewStatus status,
+    String? note,
+    @DateTimeUtcConverter() required DateTime createdAt,
+    @DateTimeUtcConverter() required DateTime updatedAt,
+  }) = _ReviewHistoryDto;
+
+  factory ReviewHistoryDto.fromJson(Map<String, dynamic> json) =>
+      _$ReviewHistoryDtoFromJson(json);
+}

--- a/spaced_learning_app/lib/features/review_history/data/models/review_history_update_request_dto.dart
+++ b/spaced_learning_app/lib/features/review_history/data/models/review_history_update_request_dto.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:spaced_learning_app/features/review_history/domain/entities/review_status.dart';
+
+part 'review_history_update_request_dto.freezed.dart';
+part 'review_history_update_request_dto.g.dart';
+
+@freezed
+class ReviewHistoryUpdateRequestDto with _$ReviewHistoryUpdateRequestDto {
+  const factory ReviewHistoryUpdateRequestDto({
+    int? score,
+    ReviewStatus? status,
+    String? note,
+  }) = _ReviewHistoryUpdateRequestDto;
+
+  factory ReviewHistoryUpdateRequestDto.fromJson(Map<String, dynamic> json) =>
+      _$ReviewHistoryUpdateRequestDtoFromJson(json);
+}

--- a/spaced_learning_app/lib/features/review_history/data/repositories/review_history_repository_impl.dart
+++ b/spaced_learning_app/lib/features/review_history/data/repositories/review_history_repository_impl.dart
@@ -1,0 +1,67 @@
+import 'package:dio/dio.dart';
+import 'package:spaced_learning_app/core/exceptions/app_exceptions.dart';
+import 'package:spaced_learning_app/core/exceptions/parse_exception.dart';
+import 'package:spaced_learning_app/core/pagination/page.dart';
+import 'package:spaced_learning_app/features/review_history/data/datasources/review_history_remote_data_source.dart';
+import 'package:spaced_learning_app/features/review_history/data/mappers/review_history_mapper.dart';
+import 'package:spaced_learning_app/features/review_history/domain/entities/review_history.dart';
+import 'package:spaced_learning_app/features/review_history/domain/entities/review_history_create.dart';
+import 'package:spaced_learning_app/features/review_history/domain/entities/review_history_update.dart';
+import 'package:spaced_learning_app/features/review_history/domain/repositories/review_history_repository.dart';
+
+class ReviewHistoryRepositoryImpl implements ReviewHistoryRepository {
+  final ReviewHistoryRemoteDataSource _remote;
+
+  ReviewHistoryRepositoryImpl(this._remote);
+
+  @override
+  Future<ReviewHistory> create(ReviewHistoryCreate request) async {
+    try {
+      final dto = ReviewHistoryMapper.toCreateDto(request);
+      final result = await _remote.create(dto);
+      return ReviewHistoryMapper.fromDto(result);
+    } on DioException catch (e) {
+      throw ServerException(e.message);
+    } on ParseException {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<ReviewHistory> update(String id, ReviewHistoryUpdate request) async {
+    try {
+      final dto = ReviewHistoryMapper.toUpdateDto(request);
+      final result = await _remote.update(id, dto);
+      return ReviewHistoryMapper.fromDto(result);
+    } on DioException catch (e) {
+      throw ServerException(e.message);
+    } on ParseException {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<ReviewHistory> getById(String id) async {
+    try {
+      final result = await _remote.getById(id);
+      return ReviewHistoryMapper.fromDto(result);
+    } on DioException catch (e) {
+      throw ServerException(e.message);
+    } on ParseException {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<Page<ReviewHistory>> getBySet(String setId,
+      {int page = 0, int size = 20}) async {
+    try {
+      final result = await _remote.getBySet(setId, page, size);
+      return ReviewHistoryMapper.mapPage(result);
+    } on DioException catch (e) {
+      throw ServerException(e.message);
+    } on ParseException {
+      rethrow;
+    }
+  }
+}

--- a/spaced_learning_app/lib/features/review_history/domain/entities/review_history.dart
+++ b/spaced_learning_app/lib/features/review_history/domain/entities/review_history.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../core/converters/datetime_utc_converter.dart';
+import 'review_status.dart';
+
+part 'review_history.freezed.dart';
+
+@freezed
+class ReviewHistory with _$ReviewHistory {
+  const factory ReviewHistory({
+    required String id,
+    required String setId,
+    required String setName,
+    required int cycleNo,
+    required int reviewNo,
+    int? score,
+    required ReviewStatus status,
+    String? note,
+    @DateTimeUtcConverter() required DateTime createdAt,
+    @DateTimeUtcConverter() required DateTime updatedAt,
+  }) = _ReviewHistory;
+}

--- a/spaced_learning_app/lib/features/review_history/domain/entities/review_history_create.dart
+++ b/spaced_learning_app/lib/features/review_history/domain/entities/review_history_create.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'review_status.dart';
+
+part 'review_history_create.freezed.dart';
+
+@freezed
+class ReviewHistoryCreate with _$ReviewHistoryCreate {
+  const factory ReviewHistoryCreate({
+    required String setId,
+    required int cycleNo,
+    required int reviewNo,
+    int? score,
+    required ReviewStatus status,
+    String? note,
+  }) = _ReviewHistoryCreate;
+}

--- a/spaced_learning_app/lib/features/review_history/domain/entities/review_history_update.dart
+++ b/spaced_learning_app/lib/features/review_history/domain/entities/review_history_update.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'review_status.dart';
+
+part 'review_history_update.freezed.dart';
+
+@freezed
+class ReviewHistoryUpdate with _$ReviewHistoryUpdate {
+  const factory ReviewHistoryUpdate({
+    int? score,
+    ReviewStatus? status,
+    String? note,
+  }) = _ReviewHistoryUpdate;
+}

--- a/spaced_learning_app/lib/features/review_history/domain/entities/review_status.dart
+++ b/spaced_learning_app/lib/features/review_history/domain/entities/review_status.dart
@@ -1,0 +1,12 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'review_status.g.dart';
+
+@JsonEnum(unknownEnumValue: ReviewStatus.unknown)
+enum ReviewStatus {
+  @JsonValue('COMPLETED')
+  completed,
+  @JsonValue('SKIPPED')
+  skipped,
+  unknown,
+}

--- a/spaced_learning_app/lib/features/review_history/domain/repositories/review_history_repository.dart
+++ b/spaced_learning_app/lib/features/review_history/domain/repositories/review_history_repository.dart
@@ -1,0 +1,11 @@
+import '../../../../core/pagination/page.dart';
+import '../entities/review_history.dart';
+import '../entities/review_history_create.dart';
+import '../entities/review_history_update.dart';
+
+abstract class ReviewHistoryRepository {
+  Future<ReviewHistory> create(ReviewHistoryCreate request);
+  Future<ReviewHistory> update(String id, ReviewHistoryUpdate request);
+  Future<ReviewHistory> getById(String id);
+  Future<Page<ReviewHistory>> getBySet(String setId, {int page = 0, int size = 20});
+}

--- a/spaced_learning_app/lib/features/review_history/domain/usecases/create_review_history.dart
+++ b/spaced_learning_app/lib/features/review_history/domain/usecases/create_review_history.dart
@@ -1,0 +1,12 @@
+import '../entities/review_history.dart';
+import '../entities/review_history_create.dart';
+import '../repositories/review_history_repository.dart';
+
+class CreateReviewHistory {
+  final ReviewHistoryRepository _repository;
+  CreateReviewHistory(this._repository);
+
+  Future<ReviewHistory> call(ReviewHistoryCreate request) {
+    return _repository.create(request);
+  }
+}

--- a/spaced_learning_app/lib/features/review_history/domain/usecases/get_reviews_by_set.dart
+++ b/spaced_learning_app/lib/features/review_history/domain/usecases/get_reviews_by_set.dart
@@ -1,0 +1,12 @@
+import '../entities/review_history.dart';
+import '../repositories/review_history_repository.dart';
+import '../../../../core/pagination/page.dart';
+
+class GetReviewsBySet {
+  final ReviewHistoryRepository _repository;
+  GetReviewsBySet(this._repository);
+
+  Future<Page<ReviewHistory>> call(String setId, {int page = 0, int size = 20}) {
+    return _repository.getBySet(setId, page: page, size: size);
+  }
+}

--- a/spaced_learning_app/lib/features/review_history/domain/usecases/update_review_history.dart
+++ b/spaced_learning_app/lib/features/review_history/domain/usecases/update_review_history.dart
@@ -1,0 +1,12 @@
+import '../entities/review_history.dart';
+import '../entities/review_history_update.dart';
+import '../repositories/review_history_repository.dart';
+
+class UpdateReviewHistory {
+  final ReviewHistoryRepository _repository;
+  UpdateReviewHistory(this._repository);
+
+  Future<ReviewHistory> call(String id, ReviewHistoryUpdate request) {
+    return _repository.update(id, request);
+  }
+}

--- a/spaced_learning_app/lib/features/review_history/presentation/notifiers/review_history_list_notifier.dart
+++ b/spaced_learning_app/lib/features/review_history/presentation/notifiers/review_history_list_notifier.dart
@@ -1,0 +1,29 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:spaced_learning_app/features/review_history/presentation/states/review_history_list_state.dart';
+
+import '../providers/review_history_providers.dart';
+
+part 'review_history_list_notifier.g.dart';
+
+@riverpod
+class ReviewHistoryListNotifier extends _$ReviewHistoryListNotifier {
+  @override
+  ReviewHistoryListState build(String setId) {
+    return const ReviewHistoryListState.initial();
+  }
+
+  Future<void> fetch({int page = 0, int size = 20}) async {
+    state = const ReviewHistoryListState.loading();
+    final usecase = ref.read(getReviewsBySetProvider);
+    try {
+      final result = await usecase(setId, page: page, size: size);
+      if (result.content.isEmpty) {
+        state = const ReviewHistoryListState.empty();
+        return;
+      }
+      state = ReviewHistoryListState.data(result);
+    } catch (e) {
+      state = ReviewHistoryListState.error(e.toString());
+    }
+  }
+}

--- a/spaced_learning_app/lib/features/review_history/presentation/providers/review_history_providers.dart
+++ b/spaced_learning_app/lib/features/review_history/presentation/providers/review_history_providers.dart
@@ -1,0 +1,41 @@
+import 'package:dio/dio.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:spaced_learning_app/core/constants/app_constants.dart';
+import 'package:spaced_learning_app/features/review_history/data/datasources/review_history_remote_data_source.dart';
+import 'package:spaced_learning_app/features/review_history/data/repositories/review_history_repository_impl.dart';
+import 'package:spaced_learning_app/features/review_history/domain/repositories/review_history_repository.dart';
+import 'package:spaced_learning_app/features/review_history/domain/usecases/create_review_history.dart';
+import 'package:spaced_learning_app/features/review_history/domain/usecases/get_reviews_by_set.dart';
+import 'package:spaced_learning_app/features/review_history/domain/usecases/update_review_history.dart';
+
+part 'review_history_providers.g.dart';
+
+@riverpod
+ReviewHistoryRemoteDataSource reviewHistoryRemoteDataSource(Ref ref) {
+  final dio = Dio(
+    BaseOptions(baseUrl: AppConstants.baseUrl + AppConstants.apiPrefix),
+  );
+  return ReviewHistoryRemoteDataSource(dio);
+}
+
+@riverpod
+ReviewHistoryRepository reviewHistoryRepository(Ref ref) {
+  return ReviewHistoryRepositoryImpl(
+    ref.watch(reviewHistoryRemoteDataSourceProvider),
+  );
+}
+
+@riverpod
+GetReviewsBySet getReviewsBySet(Ref ref) {
+  return GetReviewsBySet(ref.watch(reviewHistoryRepositoryProvider));
+}
+
+@riverpod
+CreateReviewHistory createReviewHistory(Ref ref) {
+  return CreateReviewHistory(ref.watch(reviewHistoryRepositoryProvider));
+}
+
+@riverpod
+UpdateReviewHistory updateReviewHistory(Ref ref) {
+  return UpdateReviewHistory(ref.watch(reviewHistoryRepositoryProvider));
+}

--- a/spaced_learning_app/lib/features/review_history/presentation/states/review_history_list_state.dart
+++ b/spaced_learning_app/lib/features/review_history/presentation/states/review_history_list_state.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:spaced_learning_app/core/pagination/page.dart';
+import 'package:spaced_learning_app/features/review_history/domain/entities/review_history.dart';
+
+part 'review_history_list_state.freezed.dart';
+
+@freezed
+class ReviewHistoryListState with _$ReviewHistoryListState {
+  const factory ReviewHistoryListState.initial() = _Initial;
+  const factory ReviewHistoryListState.loading() = _Loading;
+  const factory ReviewHistoryListState.data(Page<ReviewHistory> page) = _Data;
+  const factory ReviewHistoryListState.empty() = _Empty;
+  const factory ReviewHistoryListState.error(String message) = _Error;
+}

--- a/spaced_learning_app/pubspec.yaml
+++ b/spaced_learning_app/pubspec.yaml
@@ -75,6 +75,7 @@ dependencies:
   # Riverpod
   flutter_riverpod: ^2.6.1
   riverpod_annotation: ^2.6.1
+  freezed_annotation: ^2.4.1
   url_launcher: ^6.1.14
 
 dev_dependencies:
@@ -92,6 +93,7 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   build_runner: ^2.4.15
   json_serializable: ^6.9.5
+  freezed: ^2.5.2
 
   # Code generation
   riverpod_generator: ^2.6.5

--- a/spaced_learning_app/test/review_history_mapper_test.dart
+++ b/spaced_learning_app/test/review_history_mapper_test.dart
@@ -1,0 +1,51 @@
+import 'package:spaced_learning_app/features/review_history/data/mappers/review_history_mapper.dart';
+import 'package:spaced_learning_app/features/review_history/data/models/review_history_dto.dart';
+
+void main() {
+  final validJson = {
+    'id': '1',
+    'setId': '2',
+    'setName': 'Set A',
+    'cycleNo': 1,
+    'reviewNo': 1,
+    'score': 80,
+    'status': 'COMPLETED',
+    'note': 'ok',
+    'createdAt': '2024-01-01T00:00:00Z',
+    'updatedAt': '2024-01-01T00:00:00Z'
+  };
+  final dto = ReviewHistoryDto.fromJson(validJson);
+  print('Valid -> ${ReviewHistoryMapper.fromDto(dto)}');
+
+  final missingJson = {
+    'id': '',
+    'setId': '2',
+    'setName': 'Set A',
+    'cycleNo': 1,
+    'reviewNo': 1,
+    'status': 'COMPLETED',
+    'createdAt': '2024-01-01T00:00:00Z',
+    'updatedAt': '2024-01-01T00:00:00Z'
+  };
+  try {
+    ReviewHistoryMapper.fromDto(ReviewHistoryDto.fromJson(missingJson));
+  } catch (e) {
+    print('Missing -> $e');
+  }
+
+  final invalidDateJson = {
+    'id': '1',
+    'setId': '2',
+    'setName': 'Set A',
+    'cycleNo': 1,
+    'reviewNo': 1,
+    'status': 'COMPLETED',
+    'createdAt': 'invalid',
+    'updatedAt': '2024-01-01T00:00:00Z'
+  };
+  try {
+    ReviewHistoryDto.fromJson(invalidDateJson);
+  } catch (e) {
+    print('Invalid date -> $e');
+  }
+}


### PR DESCRIPTION
## Summary
- add review history models and repository using Riverpod and retrofit
- provide pagination helper and DateTime UTC converter
- include example mapper tests

## Testing
- `dart run build_runner build --delete-conflicting-outputs` (fails: command not found)
- `dart run test/review_history_mapper_test.dart` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a515dd2e508331809dd4f18a289461